### PR TITLE
Fix broken image paths in 15 legacy posts (2015-2018)

### DIFF
--- a/_posts/2015/2015-07-13-cetacean-density-models.md
+++ b/_posts/2015/2015-07-13-cetacean-density-models.md
@@ -1,6 +1,6 @@
 ---
 identifier: cetaceanmodels
-image: model.jpg
+image: /images/model.jpg
 lang: en
 layout: post
 link: http://www.nature.com/articles/srep22615

--- a/_posts/2016/2016-04-15-pteropods.md
+++ b/_posts/2016/2016-04-15-pteropods.md
@@ -1,6 +1,6 @@
 ---
 identifier: pteropods
-image: pteropods.png
+image: /images/pteropods.png
 lang: en
 layout: post
 link: http://onesharedocean.org/open_ocean/ecosystems/pteropods_at_risk

--- a/_posts/2016/2016-05-11-deepsea-ophiuroids.md
+++ b/_posts/2016/2016-05-11-deepsea-ophiuroids.md
@@ -1,6 +1,6 @@
 ---
 identifier: deepseaophiuroids
-image: deepseaophiuroids.png
+image: /images/deepseaophiuroids.png
 lang: en
 layout: post
 link: http://www.nature.com/nature/journal/vaop/ncurrent/full/nature17937.html

--- a/_posts/2016/2016-11-25-betadiversity.md
+++ b/_posts/2016/2016-11-25-betadiversity.md
@@ -5,7 +5,7 @@ excerpt: A global study based on time series datasets from OBIS published in Sci
   of diversity.
 feed: true
 identifier: betadiversity
-image: betadiversity.png
+image: /images/betadiversity.png
 lang: en
 layout: post
 link: http://science.sciencemag.org/content/344/6181/296.full

--- a/_posts/2016/2016-11-28-sadmodels.md
+++ b/_posts/2016/2016-11-28-sadmodels.md
@@ -4,7 +4,7 @@ excerpt: Species abundance distribution (SAD) models using OBIS and GBIF data re
   multimodality patterns are rather common and increase with ecological heterogeneity.
 feed: true
 identifier: sad
-image: SAD.png
+image: /images/SAD.png
 lang: en
 layout: post
 link: http://onlinelibrary.wiley.com/doi/10.1111/geb.12532/full

--- a/_posts/2017/2017-03-13-nee.md
+++ b/_posts/2017/2017-03-13-nee.md
@@ -5,7 +5,7 @@ excerpt: A new study published in Nature Ecology & Evolution, using data from OB
   marine fish in the North Sea.
 feed: true
 identifier: sad
-image: nee.jpg
+image: /images/nee.jpg
 lang: en
 layout: post
 link: http://www.nature.com/articles/s41559-016-0067

--- a/_posts/2017/2017-03-14-bimodal.md
+++ b/_posts/2017/2017-03-14-bimodal.md
@@ -7,7 +7,7 @@ excerpt: A recent review of the literature and available data on latitudinal gra
   and invertebrate, and all species together.
 feed: true
 identifier: biomodal
-image: bimodal2.png
+image: /images/bimodal2.png
 lang: en
 layout: post
 link: http://www.cell.com/trends/ecology-evolution/abstract/S0169-5347(17)30043-5

--- a/_posts/2017/2017-08-17-CBpaperCostello.md
+++ b/_posts/2017/2017-08-17-CBpaperCostello.md
@@ -6,7 +6,7 @@ excerpt: Costello & Chaudhary (2017) used data from OBIS to show that marine spe
   conservation priorities.
 feed: true
 identifier: biomodal
-image: depth-spp.png
+image: /images/depth-spp.png
 lang: en
 layout: post
 link: http://www.cell.com/current-biology/abstract/S0960-9822(17)30505-5

--- a/_posts/2017/2017-11-08-realms.md
+++ b/_posts/2017/2017-11-08-realms.md
@@ -5,7 +5,7 @@ excerpt: Analysis of OBIS demonstrates for the first time that the ocean can be 
   have been published in the journal Nature Communications.
 feed: true
 identifier: realms
-image: realm.png
+image: /images/realm.png
 lang: en
 layout: post
 link: https://www.nature.com/articles/s41467-017-01121-2

--- a/_posts/2017/2017-11-13-plantfeeding.md
+++ b/_posts/2017/2017-11-13-plantfeeding.md
@@ -9,7 +9,7 @@ excerpt: Poore et al. (2017) showed that the ability to eat seaweeds and plants 
   sampling in the tropics or in certain biogeographic regions.
 feed: true
 identifier: plantfeeding
-image: poore.png
+image: /images/poore.png
 lang: en
 layout: post
 link: http://dx.doi.org/10.1073/pnas.1706399114

--- a/_posts/2017/2017-12-08-ecoregions.md
+++ b/_posts/2017/2017-12-08-ecoregions.md
@@ -6,7 +6,7 @@ excerpt: A new study using data from OBIS identified 33 mesopelagic ecoregions o
   "twilight" zone; world’s second-largest cumulative ecosystem.
 feed: true
 identifier: ecoregions
-image: ecoregions.png
+image: /images/ecoregions.png
 lang: en
 layout: post
 link: http://www.sciencedirect.com/science/article/pii/S0967063717301437

--- a/_posts/2017/2017-12-15-marinespeed.md
+++ b/_posts/2017/2017-12-15-marinespeed.md
@@ -9,7 +9,7 @@ excerpt: Bosch et al. (2017) showed that while temperature is a relevant predict
   correlation groups.
 feed: true
 identifier: marinespeed
-image: marinespeed_freq_top_5_ranks.png
+image: /images/marinespeed_freq_top_5_ranks.png
 lang: en
 layout: post
 link: http://dx.doi.org/10.1111/ddi.12668

--- a/_posts/2017/2017-12-19-seals.md
+++ b/_posts/2017/2017-12-19-seals.md
@@ -6,7 +6,7 @@ excerpt: Alexander Seymour and his team at the Duke University Marine Laboratory
   Reports journal. The data are available in OBIS through our OBIS-SEAMAP node.
 feed: true
 identifier: seals
-image: seal-drone.png
+image: /images/seal-drone.png
 lang: en
 layout: post
 link: http://dx.doi.org/10.1038/srep45127

--- a/_posts/2018/2018-01-29-losers.md
+++ b/_posts/2018/2018-01-29-losers.md
@@ -6,7 +6,7 @@ excerpt: A study of the marine invertebrates living in the seas around Antarctic
   century as the Antarctic seafloor warms.
 feed: true
 identifier: losers
-image: griffiths.png
+image: /images/griffiths.png
 lang: en
 layout: post
 link: http://dx.doi.org/10.1038/nclimate3377

--- a/_posts/2018/2018-08-24-grouper.md
+++ b/_posts/2018/2018-08-24-grouper.md
@@ -7,7 +7,7 @@ excerpt: Species distribution models using data from OBIS demonstrated that futu
   season.
 feed: true
 identifier: grouper
-image: grouper.png
+image: /images/grouper.png
 lang: en
 layout: post
 link: http://dx.doi.org/10.1111/ddi.12809


### PR DESCRIPTION
These posts' image front-matter used bare filenames (e.g. 'model.jpg') instead of the site-relative path (e.g. '/images/model.jpg'). Since the image src is output directly from this field, the bare filename resolved relative to each post's own URL and never loaded - these images have been broken since the original bulk import of all posts in commit 97bbd82 (June 2025), predating this repository's current feature-branch history. It appears to have gone unreviewed simply because these are old posts unlikely to be revisited during normal development.

Verified: all 15 target image files exist at their referenced /images/
path; only the image: front-matter value changed, no other content.

Not touched: _posts/2018/2018-03-20-itvacancy.md, which has image: null intentionally (no image for that post) and is unaffected.